### PR TITLE
Revert "updates for compatibility with qt 5.15.2"

### DIFF
--- a/src/imports/fontawesome/fontawesome.pro
+++ b/src/imports/fontawesome/fontawesome.pro
@@ -1,7 +1,6 @@
 TARGET = qtcellinkfontawesomeplugin
 TARGETPATH = QtCellink/FontAwesome
 IMPORT_VERSION = 1.0
-load(qml_plugin)
 
 QT += qml
 
@@ -21,6 +20,7 @@ RESOURCES += \
     fontawesome.qrc
 
 CONFIG += no_cxx_module builtin_resources qtquickcompiler
+load(qml_plugin)
 
 ### TODO: fix qml_module.prf (no way to turn off install_qml_files)
 qmldir.files = $$qmldir_file


### PR DESCRIPTION
This reverts commit b0799b476efe046b47b7226dd34de647b7a1fd50, because it makes the plugin to be built with a wrong name. The plugin cannot be loaded because the name `libdeclarative_qtcellinkfontawesomeplugin.so` does match the plugin name `qtcellinkfontawesomeplugin` defined in `qmldir`:

    QQmlApplicationEngine failed to load component
    qrc:/qml/main.qml:7:1: module "QtCellink.FontAwesome" plugin "qtcellinkfontawesomeplugin" not found

There are at least two issues with placing `load(qml_plugin)` before
`QML_FILES` and `no_cxx_module` config:

a) `qml_module.prf` requires `QML_FILES` to be set:
   https://github.com/qt/qtbase/blob/5.15/mkspecs/features/qml_module.prf#L26

b) `qml_plugin.prf` requires `no_cxx_module` to be set:
   https://github.com/qt/qtbase/blob/5.15/mkspecs/features/qml_plugin.prf#L29