### PR TITLE
Remove Qt module requirement for using widgets

### DIFF
--- a/src/cellink/core/global.pri
+++ b/src/cellink/core/global.pri
@@ -1,5 +1,7 @@
-INCLUDEPATH += $$PWD
 DEPENDPATH += $$PWD
 
 HEADERS += \
     $$PWD/cellink.h
+
+DEFINES += \
+    QT_BUILD_CELLINK_LIB

--- a/src/cellink/widgets/3d.pri
+++ b/src/cellink/widgets/3d.pri
@@ -8,3 +8,7 @@ HEADERS += \
 
 SOURCES += \
     $$PWD/qt3dwindow.cpp
+
+include($$PWD/../core/global.pri)
+INCLUDEPATH += \
+    $$PWD/../../../..

--- a/src/cellink/widgets/codeeditor.h
+++ b/src/cellink/widgets/codeeditor.h
@@ -39,7 +39,7 @@
 #define CODEEDITOR_H
 
 #include <QtWidgets/qplaintextedit.h>
-#include <QtCellink/cellink.h>
+#include "qtcellink/src/cellink/core/cellink.h"
 
 QT_FORWARD_DECLARE_CLASS(QCompleter)
 

--- a/src/cellink/widgets/doublespinbox.h
+++ b/src/cellink/widgets/doublespinbox.h
@@ -1,8 +1,9 @@
 #ifndef DOUBLESPINBOX_H
 #define DOUBLESPINBOX_H
 
-#include <QtCellink/cellink.h>
 #include <QtWidgets/qspinbox.h>
+
+#include "qtcellink/src/cellink/core/cellink.h"
 
 class Q_CELLINK_EXPORT DoubleSpinBox : public QDoubleSpinBox
 {

--- a/src/cellink/widgets/progressindicator.h
+++ b/src/cellink/widgets/progressindicator.h
@@ -28,7 +28,7 @@
 
 #include <QColor>
 #include <QWidget>
-#include <QtCellink/cellink.h>
+#include "qtcellink/src/cellink/core/cellink.h"
 
 /*!
     \class QProgressIndicator

--- a/src/cellink/widgets/qt3dwindow.h
+++ b/src/cellink/widgets/qt3dwindow.h
@@ -53,7 +53,8 @@
 
 #include <Qt3DExtras/qt3dextras_global.h>
 #include <QtGui/QWindow>
-#include <QtCellink/cellink.h>
+
+#include "qtcellink/src/cellink/core/cellink.h"
 
 QT_BEGIN_NAMESPACE
 

--- a/src/cellink/widgets/rangeslider.h
+++ b/src/cellink/widgets/rangeslider.h
@@ -27,7 +27,7 @@
 #define RANGESLIDER_H
 
 #include <QtWidgets/qslider.h>
-#include <QtCellink/cellink.h>
+#include "qtcellink/src/cellink/core/cellink.h"
 
 class RangeSliderPrivate;
 

--- a/src/cellink/widgets/spinbox.h
+++ b/src/cellink/widgets/spinbox.h
@@ -1,8 +1,8 @@
 #ifndef SPINBOX_H
 #define SPINBOX_H
 
-#include <QtCellink/cellink.h>
 #include <QtWidgets/qspinbox.h>
+#include "qtcellink/src/cellink/core/cellink.h"
 
 class Q_CELLINK_EXPORT SpinBox : public QSpinBox
 {

--- a/src/cellink/widgets/widgets.pri
+++ b/src/cellink/widgets/widgets.pri
@@ -15,3 +15,7 @@ SOURCES += \
     $$PWD/progressindicator.cpp \
     $$PWD/rangeslider.cpp \
     $$PWD/spinbox.cpp
+
+include($$PWD/../core/global.pri)
+INCLUDEPATH += \
+    $$PWD/../../../..


### PR DESCRIPTION
Before this, the user of the widgets in this repo needed to declare a module of the contents, headers to be included via <QtCellink/..>. This has been replaced by including the files relative to this folder structure instead, so including the .pri files should be enough to use the components from now.

If you are interested in how it has been done until now, see: https://github.com/CELLINKAB/gpadpp/blob/master/src/cellink/cellink.pro