### PR TITLE
BIOX-1222: Fix build/link errors in Qt 5.15 on windows

### DIFF
--- a/src/imports/controls/controls.pro
+++ b/src/imports/controls/controls.pro
@@ -30,5 +30,5 @@ SOURCES += \
     $$PWD/progressindicator.cpp \
     $$PWD/qtcellinkcontrolsplugin.cpp
 
-CONFIG += no_cxx_module
+# CONFIG += no_cxx_module
 load(qml_plugin)

--- a/src/imports/extras/extras.pro
+++ b/src/imports/extras/extras.pro
@@ -2,8 +2,17 @@ TARGET = qtcellinkextrasplugin
 TARGETPATH = QtCellink/Extras
 IMPORT_VERSION = 1.0
 
+
 QT += qml quick
 QT_PRIVATE += core-private gui-private qml-private quick-private quicktemplates2-private
+
+versionAtLeast(QT_VERSION, 5.14.0) {
+    QT += qmlmodels qmlmodels-private
+}
+
+versionAtLeast(QT_VERSION, 5.15.0) {
+    requires(!win32)
+}
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
@@ -52,5 +61,5 @@ SOURCES += \
     $$PWD/rect.cpp \
     $$PWD/yoctolicensemodel.cpp
 
-CONFIG += no_cxx_module
+# CONFIG += no_cxx_module
 load(qml_plugin)

--- a/src/imports/fontawesome/fontawesome.pro
+++ b/src/imports/fontawesome/fontawesome.pro
@@ -19,7 +19,7 @@ SOURCES += \
 RESOURCES += \
     fontawesome.qrc
 
-CONFIG += no_cxx_module builtin_resources qtquickcompiler
+#CONFIG += no_cxx_module builtin_resources qtquickcompiler
 load(qml_plugin)
 
 ### TODO: fix qml_module.prf (no way to turn off install_qml_files)


### PR DESCRIPTION
where private class QQmlObjectModelAttached lacks dllexport macro..