### PR TITLE
Restore fontawesome to 12719d7fd7eb7e9b51512cd27b77e3a09250dd00

### DIFF
--- a/src/imports/extras/extras.pro
+++ b/src/imports/extras/extras.pro
@@ -60,4 +60,5 @@ SOURCES += \
     $$PWD/rect.cpp \
     $$PWD/yoctolicensemodel.cpp
 
+CONFIG += no_cxx_module
 load(qml_plugin)


### PR DESCRIPTION
Might work on linux, on windows the qmldir plugins need to have "declarative_" prefix