### PR TITLE
UID-157: Fix link error to QQmlObjectModelAttached::staticMetaObject due to qt-private usage

### DIFF
--- a/src/imports/controls/controls.pro
+++ b/src/imports/controls/controls.pro
@@ -30,5 +30,5 @@ SOURCES += \
     $$PWD/progressindicator.cpp \
     $$PWD/qtcellinkcontrolsplugin.cpp
 
-# CONFIG += no_cxx_module
+CONFIG += no_cxx_module
 load(qml_plugin)

--- a/src/imports/extras/componentmodel.cpp
+++ b/src/imports/extras/componentmodel.cpp
@@ -1,3 +1,4 @@
+
 /****************************************************************************
 **
 ** Copyright (C) 2021 CELLINK AB <info@cellink.com>
@@ -32,8 +33,10 @@
 
 #include "componentmodel.h"
 
-#include <QtQml/qqmlcomponent.h>
-#include <QtQml/qqmlcontext.h>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+
+#    include <QtQml/qqmlcomponent.h>
+#    include <QtQml/qqmlcontext.h>
 
 ComponentModel::ComponentModel(QObject* parent)
     : QQmlObjectModel(parent)
@@ -157,3 +160,5 @@ int ComponentModel::components_count(QQmlListProperty<QQmlComponent>* property)
     ComponentModel* model = qobject_cast<ComponentModel*>(property->object);
     return model->m_components.count();
 }
+
+#endif

--- a/src/imports/extras/componentmodel.cpp
+++ b/src/imports/extras/componentmodel.cpp
@@ -33,10 +33,8 @@
 
 #include "componentmodel.h"
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
-
-#    include <QtQml/qqmlcomponent.h>
-#    include <QtQml/qqmlcontext.h>
+#include <QtQml/qqmlcomponent.h>
+#include <QtQml/qqmlcontext.h>
 
 ComponentModel::ComponentModel(QObject* parent)
     : QQmlObjectModel(parent)
@@ -160,5 +158,3 @@ int ComponentModel::components_count(QQmlListProperty<QQmlComponent>* property)
     ComponentModel* model = qobject_cast<ComponentModel*>(property->object);
     return model->m_components.count();
 }
-
-#endif

--- a/src/imports/extras/componentmodel.h
+++ b/src/imports/extras/componentmodel.h
@@ -37,11 +37,16 @@
 #include <QtQml/qqmllist.h>
 #include <QtQml/qqmlparserstatus.h>
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
-#    include <QtQml/private/qqmlobjectmodel_p.h>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+#    pragma message( \
+        "Disabled file due to Qt 5.15 link issues with QQmlModelAttached::staticMetaObject")
 #else
-#    include <QtQmlModels/private/qqmlobjectmodel_p.h>
-#endif
+
+#    if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
+#        include <QtQml/private/qqmlobjectmodel_p.h>
+#    else
+#        include <QtQmlModels/private/qqmlobjectmodel_p.h>
+#    endif
 
 class QQmlComponent;
 class QQmlContext;
@@ -102,4 +107,5 @@ private:
     QList<QQmlComponent*> m_components;
 };
 
+#endif
 #endif // COMPONENTMODEL_H

--- a/src/imports/extras/componentmodel.h
+++ b/src/imports/extras/componentmodel.h
@@ -37,16 +37,11 @@
 #include <QtQml/qqmllist.h>
 #include <QtQml/qqmlparserstatus.h>
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-#    pragma message( \
-        "Disabled file due to Qt 5.15 link issues with QQmlModelAttached::staticMetaObject")
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
+#    include <QtQml/private/qqmlobjectmodel_p.h>
 #else
-
-#    if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
-#        include <QtQml/private/qqmlobjectmodel_p.h>
-#    else
-#        include <QtQmlModels/private/qqmlobjectmodel_p.h>
-#    endif
+#    include <QtQmlModels/private/qqmlobjectmodel_p.h>
+#endif
 
 class QQmlComponent;
 class QQmlContext;
@@ -107,5 +102,4 @@ private:
     QList<QQmlComponent*> m_components;
 };
 
-#endif
 #endif // COMPONENTMODEL_H

--- a/src/imports/extras/extras.pro
+++ b/src/imports/extras/extras.pro
@@ -2,17 +2,16 @@ TARGET = qtcellinkextrasplugin
 TARGETPATH = QtCellink/Extras
 IMPORT_VERSION = 1.0
 
-
 QT += qml quick
 QT_PRIVATE += core-private gui-private qml-private quick-private quicktemplates2-private
 
 versionAtLeast(QT_VERSION, 5.14.0) {
-    QT += qmlmodels qmlmodels-private
+    message("Using qmlmodels library as we are Qt 5.14 or later")
+    QT += qmlmodels
+    QT_PRIVATE += qmlmodels-private
 }
 
-versionAtLeast(QT_VERSION, 5.15.0) {
-    requires(!win32)
-}
+CONFIG += no_cxx_module
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
@@ -61,5 +60,4 @@ SOURCES += \
     $$PWD/rect.cpp \
     $$PWD/yoctolicensemodel.cpp
 
-# CONFIG += no_cxx_module
 load(qml_plugin)

--- a/src/imports/extras/extras.pro
+++ b/src/imports/extras/extras.pro
@@ -60,4 +60,5 @@ SOURCES += \
     $$PWD/rect.cpp \
     $$PWD/yoctolicensemodel.cpp
 
+CONFIG += no_cxx_module
 load(qml_plugin)

--- a/src/imports/extras/qtcellinkextrasplugin.cpp
+++ b/src/imports/extras/qtcellinkextrasplugin.cpp
@@ -67,11 +67,14 @@ QtCellinkExtrasPlugin::QtCellinkExtrasPlugin(QObject* parent)
 
 void QtCellinkExtrasPlugin::registerTypes(const char* uri)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+    qmlRegisterType<ComponentModel>(uri, 1, 0, "ComponentModel");
+#endif
+
     qmlRegisterSingletonType<Color>(uri, 1, 0, "Color", [](QQmlEngine* engine, QJSEngine*) -> QObject* {
         return new Color(engine);
     });
     qmlRegisterType<ColorImage>(uri, 1, 0, "ColorImage");
-    qmlRegisterType<ComponentModel>(uri, 1, 0, "ComponentModel");
     qmlRegisterType<FilterModel>(uri, 1, 0, "FilterModel");
     qmlRegisterType<HeaderDelegate>(uri, 1, 0, "HeaderDelegate");
     qmlRegisterType<IconImage>(uri, 1, 0, "IconImage");

--- a/src/imports/fontawesome/fontawesome.pro
+++ b/src/imports/fontawesome/fontawesome.pro
@@ -7,7 +7,7 @@ QT += qml
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
 QML_FILES += \
-    $$PWD/FontAwesome.qml
+    $$files(*.qml)
 
 OTHER_FILES += \
     $$PWD/qmldir \
@@ -19,8 +19,8 @@ SOURCES += \
 RESOURCES += \
     $$PWD/fontawesome.qrc
 
-CONFIG += qtquickcompiler
-linux: CONFIG += no_cxx_module builtin_resources
+CONFIG += qtquickcompiler no_cxx_module
+linux: CONFIG += builtin_resources
 
 load(qml_plugin)
 

--- a/src/imports/fontawesome/fontawesome.qrc
+++ b/src/imports/fontawesome/fontawesome.qrc
@@ -1,5 +1,6 @@
-<!DOCTYPE RCC><RCC version="1.0">
+<RCC>
     <qresource prefix="/qt-project.org/imports/QtCellink/FontAwesome">
         <file alias="Font Awesome 5 Free-Solid-900.otf">../../3rdparty/Font-Awesome/otfs/Font Awesome 5 Free-Solid-900.otf</file>
+        <file>FontAwesome.qml</file>
     </qresource>
 </RCC>

--- a/src/imports/fontawesome/qtcellinkfontawesomeplugin.cpp
+++ b/src/imports/fontawesome/qtcellinkfontawesomeplugin.cpp
@@ -19,6 +19,7 @@
 **
 ****************************************************************************/
 
+#include <QDebug>
 #include <QtQml/qqml.h>
 #include <QtQml/qqmlextensionplugin.h>
 
@@ -34,6 +35,8 @@ public:
 
     void registerTypes(const char* uri) override
     {
+        qDebug() << "Registered FontAwesome at" << uri;
+
         qmlRegisterSingletonType(QStringLiteral("qrc:/qt-project.org/imports/QtCellink/FontAwesome/"
                                                 "FontAwesome.qml"),
                                  uri,


### PR DESCRIPTION
Fixed by workaround from Qt Support, case [00430047](https://account.qt.io/s/case/5003p00002ggWdHAAU/undefined-reference-to-qqmlobjectmodelattachedstaticmetaobject)