### PR TITLE
Add MOC_DIR to include to fix Qt 5.15 linux compile issues

### DIFF
--- a/src/imports/controls/controls.pro
+++ b/src/imports/controls/controls.pro
@@ -7,6 +7,9 @@ QT_PRIVATE += core-private gui-private qml-private quick-private quicktemplates2
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 AUX_QML_FILES += \
     $$PWD/ButtonRow.qml \
     $$PWD/ComponentView.qml \

--- a/src/imports/extras/extras.pro
+++ b/src/imports/extras/extras.pro
@@ -18,6 +18,9 @@ DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 OTHER_FILES += \
     $$PWD/qmldir
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 HEADERS += \
     $$PWD/color.h \
     $$PWD/colorimage.h \

--- a/src/imports/fontawesome/fontawesome.pro
+++ b/src/imports/fontawesome/fontawesome.pro
@@ -6,6 +6,9 @@ QT += qml
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 QML_FILES += \
     $$files(*.qml)
 

--- a/src/imports/layouts/layouts.pro
+++ b/src/imports/layouts/layouts.pro
@@ -10,6 +10,9 @@ DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 OTHER_FILES += \
     $$PWD/qmldir
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 HEADERS += \
     $$PWD/layoutgroup.h
 
@@ -19,3 +22,4 @@ SOURCES += \
 
 CONFIG += no_cxx_module
 load(qml_plugin)
+

--- a/src/imports/material/material.pro
+++ b/src/imports/material/material.pro
@@ -4,6 +4,9 @@ IMPORT_VERSION = 1.0
 
 QT += qml
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 OTHER_FILES += \
     $$PWD/qmldir
 

--- a/src/imports/templates/templates.pro
+++ b/src/imports/templates/templates.pro
@@ -7,6 +7,9 @@ QT_PRIVATE += core-private gui-private qml-private quick-private quicktemplates2
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
+INCLUDEPATH += \
+    $$MOC_DIR
+
 OTHER_FILES += \
     qmldir
 

--- a/src/plugins/geometryloaders/amf/amf.pro
+++ b/src/plugins/geometryloaders/amf/amf.pro
@@ -2,7 +2,8 @@ TARGET = amfgeometryloader
 QT += core-private 3dcore 3dcore-private 3drender 3drender-private
 CONFIG += assimp
 
-INCLUDEPATH += $$MOC_DIR
+INCLUDEPATH += \
+    $$MOC_DIR
 
 HEADERS += \
     amfgeometryloader.h \

--- a/src/plugins/geometryloaders/amf/amf.pro
+++ b/src/plugins/geometryloaders/amf/amf.pro
@@ -2,6 +2,8 @@ TARGET = amfgeometryloader
 QT += core-private 3dcore 3dcore-private 3drender 3drender-private
 CONFIG += assimp
 
+INCLUDEPATH += $$MOC_DIR
+
 HEADERS += \
     amfgeometryloader.h \
     basegeometryloader_p.h


### PR DESCRIPTION
Not sure why this was suddenly needed, but Qt 5.15.9 complains when I was compiling on Linux to debug a test failure.