### PR TITLE
Fix assimp dependency

### DIFF
--- a/mkspecs/features/assimp.prf
+++ b/mkspecs/features/assimp.prf
@@ -1,0 +1,21 @@
+heartos {
+
+    isEmpty(PKG_CONFIG) {
+        heartos: PKG_CONFIG = PKG_CONFIG_PATH=$$[QT_HOST_DATA]/pkgconfig $$[QT_HOST_BINS]/pkg-config
+    }
+
+    ASSIMP_PKGS = assimp
+    packagesExist($$ASSIMP_PKGS) {
+        PKGCONFIG += $$ASSIMP_PKGS
+        CONFIG += link_pkgconfig
+        export(PKGCONFIG)
+        export(CONFIG)
+    } else {
+        error("Unable to find Assimp with pkg-config. Not installed in SDK?")
+    }
+
+    gcc:!clang: {
+        QMAKE_CXXFLAGS += -Wno-psabi
+        export(QMAKE_CXXFLAGS)
+    }
+}

--- a/src/plugins/geometryloaders/amf/amf.pro
+++ b/src/plugins/geometryloaders/amf/amf.pro
@@ -19,5 +19,10 @@ DISTFILES += \
 
 PLUGIN_TYPE = geometryloaders
 PLUGIN_CLASS_NAME = AmfGeometryLoaderPlugin
+
+load(assimp)
 load(qt_build_config)
 load(qt_plugin)
+
+exists($$BUILD_TREE/conanbuildinfo.pri):
+    include($$BUILD_TREE/conanbuildinfo.pri)

--- a/src/plugins/geometryloaders/amf/amf.pro
+++ b/src/plugins/geometryloaders/amf/amf.pro
@@ -24,5 +24,7 @@ load(assimp)
 load(qt_build_config)
 load(qt_plugin)
 
-exists($$BUILD_TREE/conanbuildinfo.pri):
+exists($$BUILD_TREE/conanbuildinfo.pri) {
+    CONFIG += conan_basic_setup
     include($$BUILD_TREE/conanbuildinfo.pri)
+}


### PR DESCRIPTION
Allow AMF loader to pick up assimp from yocto and/or conan.