### PR TITLE
BIOX-3582: Restore anti-aliased surface format

### DIFF
--- a/src/cellink/widgets/qt3dwindow_ci.cpp
+++ b/src/cellink/widgets/qt3dwindow_ci.cpp
@@ -136,22 +136,20 @@ Qt3DWindow::Qt3DWindow(QScreen* screen)
 
     resize(1024, 768);
 
-    /*
-    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
-#ifdef QT_OPENGL_ES_2
-    format.setRenderableType(QSurfaceFormat::OpenGLES);
-#else
-    if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
+    auto format = QSurfaceFormat::defaultFormat();
+    if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES) {
+        format.setRenderableType(QSurfaceFormat::OpenGLES);
+    } else if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
         format.setVersion(4, 3);
         format.setProfile(QSurfaceFormat::CoreProfile);
     }
-#endif
+
     format.setDepthBufferSize(24);
     format.setSamples(4);
     format.setStencilBufferSize(8);
     setFormat(format);
-    */
-    //    QSurfaceFormat::setDefaultFormat(format);
+    // must set default format to see change?!
+    QSurfaceFormat::setDefaultFormat(format);
 
     d->m_aspectEngine->registerAspect(d->m_renderAspect);
     d->m_aspectEngine->registerAspect(d->m_inputAspect);


### PR DESCRIPTION
# Fixes BIOX-3582 - no antialiasing in 3d view

Multisample code was commented out to avoid QtWebEngine warning, but that disables anti-aliasing in the view.

## Checklist ##

* [x] - code naming makes sense
* [x] - follows style guide and/or surrounding code
* [x] - classes and free functions documented
* [ ] - unit tests added/updated
