### PR TITLE
LT-4387: Add selectionFinished signal to NodeItem

### DIFF
--- a/src/imports/extras/nodeitem.cpp
+++ b/src/imports/extras/nodeitem.cpp
@@ -528,6 +528,9 @@ void NodeItem::mouseReleaseEvent(QMouseEvent *event)
             setPressed(false);
         }
     } else {
+        if (m_selectionMode != NoSelection && m_selectionModel) {
+            emit selectionFinished();
+        }
         cancelSelection();
     }
     event->setAccepted(m_selectionMode != NoSelection && m_selectionModel);

--- a/src/imports/extras/nodeitem.h
+++ b/src/imports/extras/nodeitem.h
@@ -166,6 +166,7 @@ signals:
     void clicked(const QModelIndex &index);
     void doubleClicked(const QModelIndex &index);
     void ensureVisible(const QRectF &rect);
+    void selectionFinished();
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/imports/extras/nodeview.cpp
+++ b/src/imports/extras/nodeview.cpp
@@ -371,6 +371,7 @@ void NodeView::setNodeItem(NodeItem *nodeItem)
         disconnect(m_nodeItem, &NodeItem::nodeSpacingChanged, this, &NodeView::nodeSpacingChanged);
         disconnect(m_nodeItem, &NodeItem::nodeScaleXChanged, this, &NodeView::nodeScaleXChanged);
         disconnect(m_nodeItem, &NodeItem::nodeScaleYChanged, this, &NodeView::nodeScaleYChanged);
+        disconnect(m_nodeItem, &NodeItem::selectionFinished, this, &NodeView::selectionFinished);
     }
 
     if (nodeItem) {
@@ -399,6 +400,7 @@ void NodeView::setNodeItem(NodeItem *nodeItem)
         connect(nodeItem, &NodeItem::nodeSpacingChanged, this, &NodeView::nodeSpacingChanged);
         connect(nodeItem, &NodeItem::nodeScaleXChanged, this, &NodeView::nodeScaleXChanged);
         connect(nodeItem, &NodeItem::nodeScaleYChanged, this, &NodeView::nodeScaleYChanged);
+        connect(nodeItem, &NodeItem::selectionFinished, this, &NodeView::selectionFinished);
     }
 
     m_nodeItem = nodeItem;

--- a/src/imports/extras/nodeview.h
+++ b/src/imports/extras/nodeview.h
@@ -174,6 +174,7 @@ signals:
     void clicked(const QModelIndex &index);
     void doubleClicked(const QModelIndex &index);
     void zoomChanged(qreal factor, const QPointF &point);
+    void selectionFinished();
 
 protected slots:
     void resizeNodeItem();


### PR DESCRIPTION
Note: These changes were already reviewed, this PR serves only to merge the changes to mini-12sw branch.

Add `selectionFinished` signal which is emitted when the whole selection is finished, compared to `selectionChanged` signal which is emitted when a single index selection is done.