### PR TITLE
LT-4669: Fix DisplayText update

### DIFF
--- a/src/imports/templates/doublespinbox.cpp
+++ b/src/imports/templates/doublespinbox.cpp
@@ -150,9 +150,6 @@ bool DoubleSpinBoxPrivate::setValue(qreal newValue, bool allowWrap, bool modifie
     if (q->isComponentComplete())
         newValue = boundValue(newValue, allowWrap);
 
-    if (value == newValue)
-        return false;
-
     value = newValue;
 
     updateDisplayText();
@@ -216,8 +213,6 @@ void DoubleSpinBoxPrivate::updateDisplayText()
 void DoubleSpinBoxPrivate::setDisplayText(const QString &text)
 {
     Q_Q(DoubleSpinBox);
-    if (displayText == text)
-        return;
 
     displayText = text;
     emit q->displayTextChanged();


### PR DESCRIPTION
Due to the newValue being clamped, a second call in the function the display text won't be updated due to the new and olv values being the same, even though in the UI the text is different.