### PR TITLE
FX-1231: Specify OpenGL 2.1 for FOTON when using Qt3DWindow

### DIFF
--- a/src/cellink/widgets/qt3dwindow_ci.cpp
+++ b/src/cellink/widgets/qt3dwindow_ci.cpp
@@ -145,7 +145,12 @@ Qt3DWindow::Qt3DWindow(QScreen* screen)
     if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES) {
         format.setRenderableType(QSurfaceFormat::OpenGLES);
     } else if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL) {
+#ifdef Q_OS_FOTONOS
+        // Only OpenGL 2.1 is supported
+        format.setVersion(2, 1);
+#else
         format.setVersion(4, 3);
+#endif
         format.setProfile(QSurfaceFormat::CoreProfile);
     }
 


### PR DESCRIPTION
The desktop UI uses OpenGL 4.3 which isn't available in FOTON OS (uses 2.1).